### PR TITLE
Ability to set the source version to 'latest-snapshot'

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -28,7 +28,7 @@ fi
 release_url=$(jq -r '.source.url //empty' < $payload)
 snapshot_url=$(jq -r '.source.snapshot_url //empty' < $payload)
 artifact=$(jq -r '.source.artifact //empty' < $payload)
-version=$(jq -r '.version.version //empty' < $payload)
+version=$(jq -r '.source.version //.version.version //empty' < $payload)
 username=$(jq -r '.source.username //empty' < $payload)
 password=$(jq -r '.source.password //empty' < $payload)
 skip_cert_check=$(jq -r '.source.skip_cert_check //empty' < $payload)
@@ -69,6 +69,14 @@ if [[ "$version" = *-SNAPSHOT ]]; then
   [ -n "$snapshot_url" ] && url=$snapshot_url
   metadataUrl="$url/${groupId//.//}/$artifactId/$version/maven-metadata.xml"
 else
+  if [ "$version" = "latest-snapshot" ]; then
+    if [ -n "$snapshot_url" ]; then
+      url=$snapshot_url
+    else
+      printf '\e[91m[ERROR]\e[0m invalid payload (must specify snapshot_url)\n'
+      exit 1
+    fi
+  fi
   metadataUrl="$url/${groupId//.//}/$artifactId/maven-metadata.xml"
 fi
 
@@ -88,6 +96,12 @@ if [[ "$version" = *-SNAPSHOT ]]; then
   else
     versions[1]=$(echo $metadata | xmllint --xpath "/metadata/versioning/snapshotVersions/snapshotVersion[extension='$packaging' and classifier='$classifier']/value/text()" - 2>/dev/null)
   fi
+elif [ "$version" = "latest-snapshot" ]; then
+  version=$(echo $metadata | xmllint --xpath "/metadata/versioning/versions/version[last()]/text()" - 2>/dev/null)
+  #The latest snapshot version is now known, so the script may be re-entered with an updated payload to get the unique version.
+  jq --arg version "$version" '.source.version=$version' < $payload | $0 >&3
+  #Second invocation of the script would have written the output, so we are done here.
+  exit $?
 elif [ "$version" = "latest" ] || [ -z "$version" ]; then
   versions[1]=$(echo $metadata | xmllint --xpath "/metadata/versioning/versions/version[last()]/text()" - 2>/dev/null)
 else

--- a/itest/all.sh
+++ b/itest/all.sh
@@ -16,9 +16,6 @@ source $BASE_DIR/test/helpers.sh
 : "${MVN_REPO_CERT:=}"
 : "${MVN_DISABLE_REDEPLOY:=false}"
 
-# 1.0.0-20170328.031519-19
-readonly UNIQUE_SNAPSHOT_PATTERN="\-[0-9]{8}\.[0-9]{6}-[0-9]{1,}"
-
 it_can_deploy_snapshot_using_url() {
 
   local project=$BASE_DIR/test/fixtures/project

--- a/test/check.sh
+++ b/test/check.sh
@@ -95,7 +95,53 @@ it_can_check_latest_from_three_versions() {
   '
 }
 
+it_can_check_latest_unique_version_of_particular_snapshot_from_three_versions() {
+
+  local src=$(mktemp -d $TMPDIR/check-src.XXXXXX)
+
+  local repository=$src/remote-repository
+  mkdir -p $repository
+
+  local url=file://$repository
+  local artifact=ci.concourse.maven:maven-resource:jar:standalone
+
+  local version1=$(deploy_artifact $url $artifact '1.0.0-SNAPSHOT' $src)
+  local version2=$(deploy_artifact $url $artifact '1.0.0-SNAPSHOT' $src)
+  local version3=$(deploy_artifact $url $artifact '2.0.0-SNAPSHOT' $src)
+
+  check_artifact $url $artifact '1.0.0-SNAPSHOT' $src | \
+  jq -e \
+  --arg version $version2 \
+  '
+    . == [{version: $version}]
+  '
+}
+
+it_can_check_latest_unique_version_of_latest_snapshot_from_three_versions() {
+
+  local src=$(mktemp -d $TMPDIR/check-src.XXXXXX)
+
+  local repository=$src/remote-repository
+  mkdir -p $repository
+
+  local url=file://$repository
+  local artifact=ci.concourse.maven:maven-resource:jar:standalone
+
+  local version1=$(deploy_artifact $url $artifact '3.0.0-SNAPSHOT' $src)
+  local version2=$(deploy_artifact $url $artifact '4.0.0-SNAPSHOT' $src)
+  local version3=$(deploy_artifact $url $artifact '4.0.0-SNAPSHOT' $src)
+
+  check_artifact $url $artifact 'latest-snapshot' $src | \
+  jq -e \
+  --arg version $version3 \
+  '
+    . == [{version: $version}]
+  '
+}
+
 run it_can_check_from_one_version
 run it_can_check_from_three_versions
 run it_can_check_latest_from_one_version
 run it_can_check_latest_from_three_versions
+run it_can_check_latest_unique_version_of_particular_snapshot_from_three_versions
+run it_can_check_latest_unique_version_of_latest_snapshot_from_three_versions


### PR DESCRIPTION
The existing 'latest' behaviour only works for releases, so I added a 'latest-snapshot' option which will result in the latest unique version of the latest snapshot.

### Examples
Let's say you have the following unique versions of your artifact:
**1.0.0-SNAPSHOT:**
* 1.0.0-20170328.031519-19
* 1.0.0-20180429.041620-20

**2.0.0-SNAPSHOT:**
* 2.0.0-20190101.010101-01
* 2.0.0-20190202.020202-02

Then these are the results you will get by setting the **source.version** to the following values:

| source.version | Resulting JSON |
| --- | --- |
| 1.0.0-SNAPSHOT | [{"version": "1.0.0-20180429.041620-20"}] |
| 2.0.0-SNAPSHOT | [{"version": "2.0.0-20190202.020202-02"}] |
| latest-snapshot | [{"version": "2.0.0-20190202.020202-02"}] |

 